### PR TITLE
Ignore Serena local metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local tooling metadata
+.serena/


### PR DESCRIPTION
## 概要
- .gitignore に .serena/ を追加
- Serena のローカル設定やメモが未追跡ノイズとして出ないように調整

## 確認内容
- git check-ignore -v .serena .serena/project.yml .serena/memories/project_overview.md
- git status --short --ignored

## テスト
- 未実行（.gitignore のみの変更のため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration to exclude local tooling metadata from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->